### PR TITLE
Babel v7 compatibility

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015"]
+  "presets": ["@babel/preset-es2015"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+package-lock.json
 npm-debug.log
 .idea
 *.sublime-project

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased changes
 
+* Via [#3](https://github.com/newoga/babel-plugin-transform-replace-object-assign/pull/3):
+  * Updated dependencies.
+  * New plugin implementation for Babel v7.
+  * Use [@babel/helper-module-imports](https://npm.im/@babel/helper-module-imports) so the output is either ESM or CJS depending if `sourceType` is `module` or `script`, fixing [#1](https://github.com/newoga/babel-plugin-transform-replace-object-assign/issues/1).
+  * Added [`@babel/core`](https://npm.im/@babel/core) peer dependency, as Babel does for official plugins.
+  * Disabled and ignored `package-lock.json`.
+  * Replaced `lodash.assign` in readme examples with `object-assign` to demo defaults.
+  * New way to register Babel for Mocha tests.
+
 ## 1.0.0
 
 * The plugin configuration is now optional. If no configuration is provided, the `Object.assign` implementation will be replaced with [object-assign](https://github.com/sindresorhus/object-assign).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
     "plugins": [
       [
         "transform-replace-object-assign",
-        { "moduleSpecifier": "custom-module}" }
+        { "moduleSpecifier": "custom-module" }
       ]
     ]
   }

--- a/README.md
+++ b/README.md
@@ -50,9 +50,7 @@ To use defaults (which is the same as above):
 
 ```json
 {
-  "plugins": [
-    "transform-replace-object-assign"
-  ]
+  "plugins": ["transform-replace-object-assign"]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ When you provide the plugin, use the `moduleSpecifier` option to specify which p
 ```json
 {
   "plugins": [
-    ["transform-replace-object-assign", { moduleSpecifier: "object-assign" }]
+    ["transform-replace-object-assign", { "moduleSpecifier": "object-assign" }]
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ To use defaults (which is the same as above):
 **In**
 
 ```js
-Object.assign(a, b)
+Object.assign(a, b);
 ```
 
 **Out**
 
 ```js
-import _objectAssign from 'object-assign'
+import _objectAssign from 'object-assign';
 
-_objectAssign(a, b)
+_objectAssign(a, b);
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ## babel-plugin-transform-replace-object-assign
-[![Build Status](https://travis-ci.org/newoga/babel-plugin-transform-replace-object-assign.svg?branch=master)](https://travis-ci.org/newoga/babel-plugin-transform-replace-object-assign)
-[![npm version](https://img.shields.io/npm/v/babel-plugin-transform-replace-object-assign.svg?style=flat-square)](https://www.npmjs.com/package/babel-plugin-transform-replace-object-assign)
-[![npm downloads](https://img.shields.io/npm/dm/babel-plugin-transform-replace-object-assign.svg?style=flat-square)](https://www.npmjs.com/package/babel-plugin-transform-replace-object-assign)
+
+[![Build Status](https://travis-ci.org/newoga/babel-plugin-transform-replace-object-assign.svg?branch=master)](https://travis-ci.org/newoga/babel-plugin-transform-replace-object-assign) [![npm version](https://img.shields.io/npm/v/babel-plugin-transform-replace-object-assign.svg?style=flat-square)](https://www.npmjs.com/package/babel-plugin-transform-replace-object-assign) [![npm downloads](https://img.shields.io/npm/dm/babel-plugin-transform-replace-object-assign.svg?style=flat-square)](https://www.npmjs.com/package/babel-plugin-transform-replace-object-assign)
 
 Replaces `Object.assign` with a custom implementation that you provide in plugin configuration. This plugin works similarly to the [babel-plugin-transform-object-assign](https://www.npmjs.com/package/babel-plugin-transform-object-assign) plugin except it allows you to provide your own implementation that you would like to replace `Object.assign` with rather than the `_extends` helper that Babel uses.
 
@@ -12,6 +11,7 @@ The implementation you configure is specified as a npm package dependency.
 ---
 
 #### ⚠️ Important note on the use of this project:
+
 Most likely you do not and should not use this plugin! I initially wrote this plugin due to a [bug](https://bugs.chromium.org/p/v8/issues/detail?id=4118) in Chrome where key order was not gaurenteed to be correct for objects mutated with `Object.assign` (the issue is also described at [sindresorhus/object-assign#22](https://github.com/sindresorhus/object-assign/issues/22)).
 
 While the bug did not cause problems for most projects, it did causes problems for a project I was helping maintain ([Material-UI](https://github.com/callemall/material-ui)). We heavily used `Object.assign` to merge style definitions that were defined in javascript objects. Since key order is important when defining CSS style rules, the `Object.assign` implementation built into Chrome caused many style related bugs. This plugin allowed us to completely replace all uses of `Object.assign` within our source code with an implementation that did not break in Chrome (with the expectation that we would stop using this plugin when the bug was fixed and rolled out to a majority of Chrome users).
@@ -26,23 +26,33 @@ The bug in Chrome has been fixed for quite some time now (it was fixed in Chrome
 
 ```sh
 # Install the plugin
-$ npm install babel-plugin-transform-replace-object-assign
+$ npm install --save-dev babel-plugin-transform-replace-object-assign
 
 # Install an assign implementation
-$ npm install lodash.assign
+$ npm install object-assign
 ```
 
 #### Configure
 
-When you provide the plugin, also specify which package you would like imported and used when replacing `Object.assign`.
+When you provide the plugin, use the `moduleSpecifier` option to specify which package you would like imported and used when replacing `Object.assign`.
 
 **.babelrc**
 
 ```json
 {
   "plugins": [
-    ["transform-replace-object-assign", "lodash.assign"]
-  ] 
+    ["transform-replace-object-assign", { moduleSpecifier: "object-assign" }]
+  ]
+}
+```
+
+To use defaults (which is the same as above):
+
+```json
+{
+  "plugins": [
+    "transform-replace-object-assign"
+  ]
 }
 ```
 
@@ -51,14 +61,13 @@ When you provide the plugin, also specify which package you would like imported 
 **In**
 
 ```js
-Object.assign(a, b);
+Object.assign(a, b)
 ```
 
 **Out**
 
 ```js
-import _lodash from 'lodash.assign';
+import _objectAssign from 'object-assign'
 
-_lodash(a, b)
-
+_objectAssign(a, b)
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,9 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = _default;
+
+var _helperModuleImports = require("@babel/helper-module-imports");
+
 var OBJECT_ASSIGN = 'ObjectAssign';
 
 function _default(_ref) {
@@ -25,8 +28,9 @@ function _default(_ref) {
 
           var _opts$moduleSpecifier = opts.moduleSpecifier,
               moduleSpecifier = _opts$moduleSpecifier === void 0 ? 'object-assign' : _opts$moduleSpecifier;
-          var declare = t.importDeclaration([t.importDefaultSpecifier(file.get(OBJECT_ASSIGN))], t.stringLiteral(moduleSpecifier));
-          path.node.body.unshift(declare);
+          (0, _helperModuleImports.addDefault)(file.path, moduleSpecifier, {
+            nameHint: file.get(OBJECT_ASSIGN)
+          });
         }
       },
       CallExpression: function CallExpression(path, _ref4) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,41 +7,23 @@ exports.default = _default;
 
 var _helperModuleImports = require("@babel/helper-module-imports");
 
-var OBJECT_ASSIGN = 'ObjectAssign';
-
 function _default(_ref) {
   var t = _ref.types;
   return {
     visitor: {
-      Program: {
-        enter: function enter(path, _ref2) {
-          var file = _ref2.file;
-          file.set(OBJECT_ASSIGN, false);
-        },
-        exit: function exit(path, _ref3) {
-          var file = _ref3.file,
-              opts = _ref3.opts;
-
-          if (!file.get(OBJECT_ASSIGN) && !path.scope.hasBinding(opts)) {
-            return;
-          }
-
-          var _opts$moduleSpecifier = opts.moduleSpecifier,
-              moduleSpecifier = _opts$moduleSpecifier === void 0 ? 'object-assign' : _opts$moduleSpecifier;
-          (0, _helperModuleImports.addDefault)(file.path, moduleSpecifier, {
-            nameHint: file.get(OBJECT_ASSIGN)
-          });
-        }
-      },
-      CallExpression: function CallExpression(path, _ref4) {
-        var file = _ref4.file;
+      CallExpression: function CallExpression(path, _ref2) {
+        var file = _ref2.file,
+            opts = _ref2.opts;
 
         if (path.get('callee').matchesPattern('Object.assign')) {
-          if (!file.get(OBJECT_ASSIGN)) {
-            file.set(OBJECT_ASSIGN, path.scope.generateUidIdentifier('objectAssign'));
+          var _opts$moduleSpecifier = opts.moduleSpecifier,
+              moduleSpecifier = _opts$moduleSpecifier === void 0 ? 'object-assign' : _opts$moduleSpecifier;
+          if (this.importCache) path.node.callee = t.cloneNode(this.importCache);else {
+            this.importCache = (0, _helperModuleImports.addDefault)(file.path, moduleSpecifier, {
+              nameHint: 'objectAssign'
+            });
+            path.node.callee = this.importCache;
           }
-
-          path.node.callee = file.get(OBJECT_ASSIGN);
         }
       }
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,12 +16,10 @@ function _default(_ref) {
             opts = _ref2.opts;
 
         if (path.get('callee').matchesPattern('Object.assign')) {
-          var _opts$moduleSpecifier = opts.moduleSpecifier,
-              moduleSpecifier = _opts$moduleSpecifier === void 0 ? 'object-assign' : _opts$moduleSpecifier;
           if (this.importCache) path.node.callee = t.cloneNode(this.importCache);else {
-            this.importCache = (0, _helperModuleImports.addDefault)(file.path, moduleSpecifier, {
-              nameHint: 'objectAssign'
-            });
+            var _opts$moduleSpecifier = opts.moduleSpecifier,
+                moduleSpecifier = _opts$moduleSpecifier === void 0 ? 'object-assign' : _opts$moduleSpecifier;
+            this.importCache = (0, _helperModuleImports.addDefault)(file.path, moduleSpecifier);
             path.node.callee = this.importCache;
           }
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,39 +1,38 @@
-'use strict';
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.default = _default;
+var OBJECT_ASSIGN = 'ObjectAssign';
 
-exports.default = function (_ref) {
+function _default(_ref) {
   var t = _ref.types;
-
   return {
     visitor: {
       Program: {
         enter: function enter(path, _ref2) {
           var file = _ref2.file;
-
           file.set(OBJECT_ASSIGN, false);
         },
         exit: function exit(path, _ref3) {
-          var file = _ref3.file;
-          var opts = _ref3.opts;
+          var file = _ref3.file,
+              opts = _ref3.opts;
 
           if (!file.get(OBJECT_ASSIGN) && !path.scope.hasBinding(opts)) {
             return;
           }
 
-          var declar = t.importDeclaration([t.importDefaultSpecifier(file.get(OBJECT_ASSIGN))], t.stringLiteral(opts));
-
-          path.node.body.unshift(declar);
+          var _opts$moduleSpecifier = opts.moduleSpecifier,
+              moduleSpecifier = _opts$moduleSpecifier === void 0 ? 'object-assign' : _opts$moduleSpecifier;
+          var declare = t.importDeclaration([t.importDefaultSpecifier(file.get(OBJECT_ASSIGN))], t.stringLiteral(moduleSpecifier));
+          path.node.body.unshift(declare);
         }
       },
-
       CallExpression: function CallExpression(path, _ref4) {
         var file = _ref4.file;
 
         if (path.get('callee').matchesPattern('Object.assign')) {
-
           if (!file.get(OBJECT_ASSIGN)) {
             file.set(OBJECT_ASSIGN, path.scope.generateUidIdentifier('objectAssign'));
           }
@@ -43,6 +42,4 @@ exports.default = function (_ref) {
       }
     }
   };
-};
-
-var OBJECT_ASSIGN = 'ObjectAssign';
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "babel",
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-module-imports": "^7.0.0-beta.42"
+  },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.42",
     "@babel/core": "^7.0.0-beta.42",

--- a/package.json
+++ b/package.json
@@ -1,15 +1,12 @@
 {
   "name": "babel-plugin-transform-replace-object-assign",
   "version": "0.2.0",
-  "description":
-    "Allows you to provide custom implementation of Object.assign in babel builds",
+  "description": "Allows you to provide custom implementation of Object.assign in babel builds",
   "repository": {
     "type": "git",
-    "url":
-      "https://github.com/newoga/babel-plugin-transform-replace-object-assign"
+    "url": "https://github.com/newoga/babel-plugin-transform-replace-object-assign"
   },
-  "author":
-    "Neil Gabbadon <neil.gabbadon@gmail.com> (https://github.com/newoga)",
+  "author": "Neil Gabbadon <neil.gabbadon@gmail.com> (https://github.com/newoga)",
   "license": "MIT",
   "main": "lib/index.js",
   "scripts": {
@@ -18,7 +15,11 @@
     "build": "babel src --out-dir lib",
     "prepublish": "npm run build"
   },
-  "keywords": ["assign", "babel", "babel-plugin"],
+  "keywords": [
+    "assign",
+    "babel",
+    "babel-plugin"
+  ],
   "dependencies": {
     "@babel/helper-module-imports": "^7.0.0-beta.42"
   },
@@ -28,12 +29,6 @@
     "@babel/preset-es2015": "^7.0.0-beta.42",
     "@babel/register": "^7.0.0-beta.42",
     "istanbul": "^0.4.2",
-    "mocha": "^5.0.4",
-    "prettier": "^1.11.1"
-  },
-  "prettier": {
-    "proseWrap": "never",
-    "singleQuote": true,
-    "semi": false
+    "mocha": "^5.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "babel-plugin"
   ],
   "devDependencies": {
-    "babel-cli": "^6.4.5",
-    "babel-core": "^6.4.5",
-    "babel-preset-es2015": "^6.3.13",
+    "@babel/cli": "^7.0.0-beta.42",
+    "@babel/core": "^7.0.0-beta.42",
+    "@babel/preset-es2015": "^7.0.0-beta.42",
+    "@babel/register": "^7.0.0-beta.42",
     "istanbul": "^0.4.2",
-    "mocha": "^2.4.5",
-    "simple-assign": "0.1.0"
+    "mocha": "^5.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "babel",
     "babel-plugin"
   ],
+  "peerDependencies": {
+    "@babel/core": "^7.0.0-beta.42"
+  },
   "dependencies": {
     "@babel/helper-module-imports": "^7.0.0-beta.42"
   },

--- a/package.json
+++ b/package.json
@@ -1,12 +1,15 @@
 {
   "name": "babel-plugin-transform-replace-object-assign",
   "version": "0.2.0",
-  "description": "Allows you to provide custom implementation of Object.assign in babel builds",
+  "description":
+    "Allows you to provide custom implementation of Object.assign in babel builds",
   "repository": {
     "type": "git",
-    "url": "https://github.com/newoga/babel-plugin-transform-replace-object-assign"
+    "url":
+      "https://github.com/newoga/babel-plugin-transform-replace-object-assign"
   },
-  "author": "Neil Gabbadon <neil.gabbadon@gmail.com> (https://github.com/newoga)",
+  "author":
+    "Neil Gabbadon <neil.gabbadon@gmail.com> (https://github.com/newoga)",
   "license": "MIT",
   "main": "lib/index.js",
   "scripts": {
@@ -15,11 +18,7 @@
     "build": "babel src --out-dir lib",
     "prepublish": "npm run build"
   },
-  "keywords": [
-    "assign",
-    "babel",
-    "babel-plugin"
-  ],
+  "keywords": ["assign", "babel", "babel-plugin"],
   "dependencies": {
     "@babel/helper-module-imports": "^7.0.0-beta.42"
   },
@@ -29,6 +28,12 @@
     "@babel/preset-es2015": "^7.0.0-beta.42",
     "@babel/register": "^7.0.0-beta.42",
     "istanbul": "^0.4.2",
-    "mocha": "^5.0.4"
+    "mocha": "^5.0.4",
+    "prettier": "^1.11.1"
+  },
+  "prettier": {
+    "proseWrap": "never",
+    "singleQuote": true,
+    "semi": false
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -5,14 +5,10 @@ export default function({ types: t }) {
     visitor: {
       CallExpression(path, { file, opts }) {
         if (path.get('callee').matchesPattern('Object.assign')) {
-          const { moduleSpecifier = 'object-assign' } = opts
-
           if (this.importCache) path.node.callee = t.cloneNode(this.importCache)
           else {
-            this.importCache = addDefault(file.path, moduleSpecifier, {
-              nameHint: 'objectAssign'
-            })
-
+            const { moduleSpecifier = 'object-assign' } = opts
+            this.importCache = addDefault(file.path, moduleSpecifier)
             path.node.callee = this.importCache
           }
         }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const OBJECT_ASSIGN = 'ObjectAssign';
 
-export default function ({types: t}) {
+export default function({types: t}) {
   return {
     visitor: {
       Program: {
@@ -13,11 +13,13 @@ export default function ({types: t}) {
             return;
           }
 
-          const declar = t.importDeclaration([
-            t.importDefaultSpecifier(file.get(OBJECT_ASSIGN)),
-          ], t.stringLiteral(opts));
+          const { moduleSpecifier = 'object-assign' } = opts
 
-          path.node.body.unshift(declar);
+          const declare = t.importDeclaration([
+            t.importDefaultSpecifier(file.get(OBJECT_ASSIGN))
+          ], t.stringLiteral(moduleSpecifier));
+
+          path.node.body.unshift(declare);
         }
       },
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,19 @@
-import { addDefault } from '@babel/helper-module-imports'
+import { addDefault } from '@babel/helper-module-imports';
 
 export default function({ types: t }) {
   return {
     visitor: {
       CallExpression(path, { file, opts }) {
         if (path.get('callee').matchesPattern('Object.assign')) {
-          if (this.importCache) path.node.callee = t.cloneNode(this.importCache)
+          if (this.importCache)
+            path.node.callee = t.cloneNode(this.importCache);
           else {
-            const { moduleSpecifier = 'object-assign' } = opts
-            this.importCache = addDefault(file.path, moduleSpecifier)
-            path.node.callee = this.importCache
+            const { moduleSpecifier = 'object-assign' } = opts;
+            this.importCache = addDefault(file.path, moduleSpecifier);
+            path.node.callee = this.importCache;
           }
         }
       }
     }
-  }
+  };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import { addDefault } from "@babel/helper-module-imports"
+
 const OBJECT_ASSIGN = 'ObjectAssign';
 
 export default function({types: t}) {
@@ -15,11 +17,11 @@ export default function({types: t}) {
 
           const { moduleSpecifier = 'object-assign' } = opts
 
-          const declare = t.importDeclaration([
-            t.importDefaultSpecifier(file.get(OBJECT_ASSIGN))
-          ], t.stringLiteral(moduleSpecifier));
-
-          path.node.body.unshift(declare);
+          addDefault(
+            file.path,
+            moduleSpecifier,
+            {nameHint: file.get(OBJECT_ASSIGN)}
+          )
         }
       },
 

--- a/test/fixtures/not-import-impl-when-no-object-assign/expected.js
+++ b/test/fixtures/not-import-impl-when-no-object-assign/expected.js
@@ -4,4 +4,3 @@ var object = {
   a: 1,
   b: 2
 };
-

--- a/test/fixtures/not-replace-non-call-expression/actual.js
+++ b/test/fixtures/not-replace-non-call-expression/actual.js
@@ -1,3 +1,3 @@
-import assign from "simple-assign";
+import assign from 'simple-assign';
 
 export default Object.assign || assign;

--- a/test/fixtures/not-replace-non-call-expression/expected.js
+++ b/test/fixtures/not-replace-non-call-expression/expected.js
@@ -3,11 +3,12 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.default = void 0;
 
-var _simpleAssign = require("simple-assign");
-
-var _simpleAssign2 = _interopRequireDefault(_simpleAssign);
+var _simpleAssign = _interopRequireDefault(require("simple-assign"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-exports.default = Object.assign || _simpleAssign2.default;
+var _default = Object.assign || _simpleAssign.default;
+
+exports.default = _default;

--- a/test/fixtures/replace-multiple-object-assign-calls/actual.js
+++ b/test/fixtures/replace-multiple-object-assign-calls/actual.js
@@ -1,2 +1,3 @@
 Object.assign({a: 1}, {b: 2});
 Object.assign({c: 3}, {d: 4});
+Object.assign({e: 5}, {f: 6});

--- a/test/fixtures/replace-multiple-object-assign-calls/actual.js
+++ b/test/fixtures/replace-multiple-object-assign-calls/actual.js
@@ -1,3 +1,3 @@
-Object.assign({a: 1}, {b: 2});
-Object.assign({c: 3}, {d: 4});
-Object.assign({e: 5}, {f: 6});
+Object.assign({ a: 1 }, { b: 2 });
+Object.assign({ c: 3 }, { d: 4 });
+Object.assign({ e: 5 }, { f: 6 });

--- a/test/fixtures/replace-multiple-object-assign-calls/expected.js
+++ b/test/fixtures/replace-multiple-object-assign-calls/expected.js
@@ -1,10 +1,17 @@
 "use strict";
 
-var _simpleAssign = require("simple-assign");
-
-var _simpleAssign2 = _interopRequireDefault(_simpleAssign);
+var _simpleAssign = _interopRequireDefault(require("simple-assign"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-(0, _simpleAssign2.default)({ a: 1 }, { b: 2 });
-(0, _simpleAssign2.default)({ c: 3 }, { d: 4 });
+(0, _simpleAssign.default)({
+  a: 1
+}, {
+  b: 2
+});
+
+_objectAssign({
+  c: 3
+}, {
+  d: 4
+});

--- a/test/fixtures/replace-multiple-object-assign-calls/expected.js
+++ b/test/fixtures/replace-multiple-object-assign-calls/expected.js
@@ -4,7 +4,7 @@ var _simpleAssign = _interopRequireDefault(require("simple-assign"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-(0, _simpleAssign.default)({
+_objectAssign({
   a: 1
 }, {
   b: 2

--- a/test/fixtures/replace-multiple-object-assign-calls/expected.js
+++ b/test/fixtures/replace-multiple-object-assign-calls/expected.js
@@ -4,14 +4,18 @@ var _simpleAssign = _interopRequireDefault(require("simple-assign"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-_simpleAssign({
+(0, _simpleAssign.default)({
   a: 1
 }, {
   b: 2
 });
-
-_simpleAssign({
+(0, _simpleAssign.default)({
   c: 3
 }, {
   d: 4
+});
+(0, _simpleAssign.default)({
+  e: 5
+}, {
+  f: 6
 });

--- a/test/fixtures/replace-multiple-object-assign-calls/expected.js
+++ b/test/fixtures/replace-multiple-object-assign-calls/expected.js
@@ -4,13 +4,13 @@ var _simpleAssign = _interopRequireDefault(require("simple-assign"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-_objectAssign({
+_simpleAssign({
   a: 1
 }, {
   b: 2
 });
 
-_objectAssign({
+_simpleAssign({
   c: 3
 }, {
   d: 4

--- a/test/fixtures/replace-single-object-assign-calls/actual.js
+++ b/test/fixtures/replace-single-object-assign-calls/actual.js
@@ -1,1 +1,1 @@
-Object.assign({'a': 1}, {'b': 2});
+Object.assign({ a: 1 }, { b: 2 });

--- a/test/fixtures/replace-single-object-assign-calls/expected.js
+++ b/test/fixtures/replace-single-object-assign-calls/expected.js
@@ -4,7 +4,7 @@ var _simpleAssign = _interopRequireDefault(require("simple-assign"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-_simpleAssign({
+(0, _simpleAssign.default)({
   'a': 1
 }, {
   'b': 2

--- a/test/fixtures/replace-single-object-assign-calls/expected.js
+++ b/test/fixtures/replace-single-object-assign-calls/expected.js
@@ -5,7 +5,7 @@ var _simpleAssign = _interopRequireDefault(require("simple-assign"));
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 (0, _simpleAssign.default)({
-  'a': 1
+  a: 1
 }, {
-  'b': 2
+  b: 2
 });

--- a/test/fixtures/replace-single-object-assign-calls/expected.js
+++ b/test/fixtures/replace-single-object-assign-calls/expected.js
@@ -4,7 +4,7 @@ var _simpleAssign = _interopRequireDefault(require("simple-assign"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-_objectAssign({
+_simpleAssign({
   'a': 1
 }, {
   'b': 2

--- a/test/fixtures/replace-single-object-assign-calls/expected.js
+++ b/test/fixtures/replace-single-object-assign-calls/expected.js
@@ -1,9 +1,11 @@
-'use strict';
+"use strict";
 
-var _simpleAssign = require('simple-assign');
-
-var _simpleAssign2 = _interopRequireDefault(_simpleAssign);
+var _simpleAssign = _interopRequireDefault(require("simple-assign"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-(0, _simpleAssign2.default)({ 'a': 1 }, { 'b': 2 });
+(0, _simpleAssign.default)({
+  'a': 1
+}, {
+  'b': 2
+});

--- a/test/fixtures/replace-single-object-assign-calls/expected.js
+++ b/test/fixtures/replace-single-object-assign-calls/expected.js
@@ -4,7 +4,7 @@ var _simpleAssign = _interopRequireDefault(require("simple-assign"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-(0, _simpleAssign.default)({
+_objectAssign({
   'a': 1
 }, {
   'b': 2

--- a/test/fixtures/use-existing-import/actual.js
+++ b/test/fixtures/use-existing-import/actual.js
@@ -1,3 +1,3 @@
-import assign from "simple-assign";
+import assign from 'simple-assign';
 
-Object.assign({a: 1}, {b: 2});
+Object.assign({ a: 1 }, { b: 2 });

--- a/test/fixtures/use-existing-import/expected.js
+++ b/test/fixtures/use-existing-import/expected.js
@@ -1,9 +1,11 @@
 "use strict";
 
-var _simpleAssign = require("simple-assign");
-
-var _simpleAssign2 = _interopRequireDefault(_simpleAssign);
+var _simpleAssign = _interopRequireDefault(require("simple-assign"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-(0, _simpleAssign2.default)({ a: 1 }, { b: 2 });
+(0, _simpleAssign.default)({
+  a: 1
+}, {
+  b: 2
+});

--- a/test/fixtures/use-existing-import/expected.js
+++ b/test/fixtures/use-existing-import/expected.js
@@ -4,7 +4,7 @@ var _simpleAssign = _interopRequireDefault(require("simple-assign"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-_objectAssign({
+_simpleAssign({
   a: 1
 }, {
   b: 2

--- a/test/fixtures/use-existing-import/expected.js
+++ b/test/fixtures/use-existing-import/expected.js
@@ -4,7 +4,7 @@ var _simpleAssign = _interopRequireDefault(require("simple-assign"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-_simpleAssign({
+(0, _simpleAssign.default)({
   a: 1
 }, {
   b: 2

--- a/test/fixtures/use-existing-import/expected.js
+++ b/test/fixtures/use-existing-import/expected.js
@@ -4,7 +4,7 @@ var _simpleAssign = _interopRequireDefault(require("simple-assign"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-(0, _simpleAssign.default)({
+_objectAssign({
   a: 1
 }, {
   b: 2

--- a/test/index.js
+++ b/test/index.js
@@ -1,27 +1,27 @@
-import path from 'path'
-import fs from 'fs'
-import assert from 'assert'
-import { transformFileSync } from '@babel/core'
-import plugin from '../src/index'
+import path from 'path';
+import fs from 'fs';
+import assert from 'assert';
+import { transformFileSync } from '@babel/core';
+import plugin from '../src/index';
 
 function trim(str) {
-  return str.replace(/^\s+|\s+$/, '')
+  return str.replace(/^\s+|\s+$/, '');
 }
 
 describe('The replace-object-assign plugin', () => {
-  const fixturesDir = path.join(__dirname, 'fixtures')
+  const fixturesDir = path.join(__dirname, 'fixtures');
   fs.readdirSync(fixturesDir).map(caseName => {
     it(`should ${caseName.split('-').join(' ')}`, () => {
-      const fixtureDir = path.join(fixturesDir, caseName)
+      const fixtureDir = path.join(fixturesDir, caseName);
       const actual = transformFileSync(path.join(fixtureDir, 'actual.js'), {
         plugins: [[plugin, { moduleSpecifier: 'simple-assign' }]]
-      }).code
+      }).code;
 
       const expected = fs
         .readFileSync(path.join(fixtureDir, 'expected.js'))
-        .toString()
+        .toString();
 
-      assert.equal(trim(actual), trim(expected))
-    })
-  })
-})
+      assert.equal(trim(actual), trim(expected));
+    });
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import assert from 'assert';
-import {transformFileSync} from 'babel-core';
+import {transformFileSync} from '@babel/core';
 import plugin from '../src/index';
 
 function trim(str) {
@@ -15,7 +15,7 @@ describe('The replace-object-assign plugin', () => {
       const fixtureDir = path.join(fixturesDir, caseName);
       const actual = transformFileSync(path.join(fixtureDir, 'actual.js'), {
         plugins: [
-          [plugin, 'simple-assign']
+          [plugin, {moduleSpecifier: 'simple-assign'}]
         ]
       }).code;
       const expected = fs.readFileSync(path.join(fixtureDir, 'expected.js')).toString();

--- a/test/index.js
+++ b/test/index.js
@@ -1,26 +1,27 @@
-import path from 'path';
-import fs from 'fs';
-import assert from 'assert';
-import {transformFileSync} from '@babel/core';
-import plugin from '../src/index';
+import path from 'path'
+import fs from 'fs'
+import assert from 'assert'
+import { transformFileSync } from '@babel/core'
+import plugin from '../src/index'
 
 function trim(str) {
-  return str.replace(/^\s+|\s+$/, '');
+  return str.replace(/^\s+|\s+$/, '')
 }
 
 describe('The replace-object-assign plugin', () => {
-  const fixturesDir = path.join(__dirname, 'fixtures');
-  fs.readdirSync(fixturesDir).map((caseName) => {
+  const fixturesDir = path.join(__dirname, 'fixtures')
+  fs.readdirSync(fixturesDir).map(caseName => {
     it(`should ${caseName.split('-').join(' ')}`, () => {
-      const fixtureDir = path.join(fixturesDir, caseName);
+      const fixtureDir = path.join(fixturesDir, caseName)
       const actual = transformFileSync(path.join(fixtureDir, 'actual.js'), {
-        plugins: [
-          [plugin, {moduleSpecifier: 'simple-assign'}]
-        ]
-      }).code;
-      const expected = fs.readFileSync(path.join(fixtureDir, 'expected.js')).toString();
+        plugins: [[plugin, { moduleSpecifier: 'simple-assign' }]]
+      }).code
 
-      assert.equal(trim(actual), trim(expected));
-    });
-  });
-});
+      const expected = fs
+        .readFileSync(path.join(fixtureDir, 'expected.js'))
+        .toString()
+
+      assert.equal(trim(actual), trim(expected))
+    })
+  })
+})

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,1 @@
---compilers js:@babel/register
+--require @babel/register

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,1 @@
---compilers js:babel-core/register
+--compilers js:@babel/register


### PR DESCRIPTION
With this update, the package should be compatible with both Babel v6 and v7.

* Updated dependencies.
* Removed the unused `simple-assign` dependency.
* Plugin options now an object instead of a string (Babel v7 requirement).
* Option is called `moduleSpecifier`:
  * This is [how it is called in the modules spec](https://tc39.github.io/ecma262/#prod-ModuleSpecifier).
  * Options default to use `object-assign`:
    * It's the most popular implementation.
    * IMO the strongest use case for `babel-plugin-transform-replace-object-assign` is to optimize React projects by configuring all plugins to output the `Object.assign` builtin (instead of helpers), then instead of polyfilling, replace all occurrences with the same `object-assign` dependency used by React.
* `declar` to `declare` variable name typo fix.
* Uses [@babel/helper-module-imports](https://github.com/babel/babel/tree/master/packages/babel-helper-module-imports) to fix https://github.com/newoga/babel-plugin-transform-replace-object-assign/issues/1. The output is either ESM or CJS depending if `sourceType` is `module` or `script`.
* Updated tests and fixtures. Babel v7 outputs slight differences.
* Disabled and ignored package-lock.json. Package lock files are for apps, not packages; npm blacklists them from ever being published.
* Updated readme for the new API.
* Replaced `lodash.assign` in readme examples with `object-assign`. It looks more intuitive and demos the defaults.