### PR TITLE
Implement object based config with default object-assign moduleSpecifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The bug in Chrome has been fixed for quite some time now (it was fixed in Chrome
 
 ```sh
 # Install the plugin
-$ npm install babel-plugin-transform-replace-object-assign
+$ npm install --save-dev babel-plugin-transform-replace-object-assign
 
 # Install an assign implementation
 $ npm install lodash.assign
@@ -41,8 +41,8 @@ When you provide the plugin, also specify which package you would like imported 
 ```json
 {
   "plugins": [
-    ["transform-replace-object-assign", "lodash.assign"]
-  ] 
+    ["transform-replace-object-assign", { "moduleSpecifier": "lodash.assign" }]
+  ]
 }
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,13 +9,19 @@ export default function ({types: t}) {
         },
 
         exit(path, {file, opts}) {
-          if (!file.get(OBJECT_ASSIGN) && !path.scope.hasBinding(opts)) {
+          if (typeof opts === 'string') {
+            throw new Error(`Configuring module specifier with a string is no longer supported. Configure with { "moduleSpecifier": "${opts}" } instead of "${opts}".`);
+          }
+
+          const { moduleSpecifier = 'object-assign' } = opts;
+
+          if (!file.get(OBJECT_ASSIGN) && !path.scope.hasBinding(moduleSpecifier)) {
             return;
           }
 
           const declar = t.importDeclaration([
             t.importDefaultSpecifier(file.get(OBJECT_ASSIGN)),
-          ], t.stringLiteral(opts));
+          ], t.stringLiteral(moduleSpecifier));
 
           path.node.body.unshift(declar);
         }

--- a/test/fixtures/use-default-config/actual.js
+++ b/test/fixtures/use-default-config/actual.js
@@ -1,0 +1,1 @@
+Object.assign({'a': 1}, {'b': 2});

--- a/test/fixtures/use-default-config/expected.js
+++ b/test/fixtures/use-default-config/expected.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var _objectAssign2 = require('object-assign');
+
+var _objectAssign3 = _interopRequireDefault(_objectAssign2);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(0, _objectAssign3.default)({ 'a': 1 }, { 'b': 2 });

--- a/test/index.js
+++ b/test/index.js
@@ -13,9 +13,13 @@ describe('The replace-object-assign plugin', () => {
   fs.readdirSync(fixturesDir).map((caseName) => {
     it(`should ${caseName.split('-').join(' ')}`, () => {
       const fixtureDir = path.join(fixturesDir, caseName);
+      const pluginConfig = [plugin];
+      if (caseName !== 'use-default-config') {
+        pluginConfig.push({ moduleSpecifier: 'simple-assign' });
+      }
       const actual = transformFileSync(path.join(fixtureDir, 'actual.js'), {
         plugins: [
-          [plugin, 'simple-assign']
+          pluginConfig
         ]
       }).code;
       const expected = fs.readFileSync(path.join(fixtureDir, 'expected.js')).toString();


### PR DESCRIPTION
This commit is based on the new API proposed by @jaydenseric in his PR newoga/babel-plugin-transform-replace-object-assign#3. His PR primarily adds support for babel 7. The PR also introduces some necessary breaking changes to the plugin configuration. This commit takes his new API and backports it to the babel 6 supported version of this plugin to ease migrations. The API changes are:

1. Configuration is now optional. If no config is provided, `object-assign` is used.
2. String based configuration is no longer supported. It must be an object with a `moduleSpecifier` key.

Documentation was updated and a new test fixture was addded to test the new default configuration behavior.